### PR TITLE
Merge SGM app into main AFL shiny app as additional tabs

### DIFF
--- a/Apps/AFL_APP/app.R
+++ b/Apps/AFL_APP/app.R
@@ -14,6 +14,10 @@ library(googlesheets4)
 library(googledrive)
 library(readxl)
 library(zoo)
+library(shinythemes)
+
+# Define helper operators
+`%notin%` <- Negate(`%in%`)
 
 # Determine the operating system
 os_type <- Sys.info()["sysname"]
@@ -149,6 +153,183 @@ player_names_odds <- sort(unique(c(
   player_kicks_data$player_name,
   player_handballs_data$player_name
 )))
+
+#===============================================================================
+# SGM App Data Loading and Functions
+#===============================================================================
+
+# Source SGM scripts
+source("betright_sgm.R")
+source("tab_sgm.R")
+source("sportsbet_sgm.R")
+source("pointsbet_sgm.R")
+source("neds_sgm.R")
+source("bet365_sgm.R")
+source("dabble_sgm.R")
+source("player_combos.R")
+
+# Matches in order
+matches_in_order <-
+  h2h_data %>%
+  distinct(match) |>
+  pull()
+
+# Compare SGM function
+compare_sgm <- function(player_names, stat_counts, markets) {
+  # Function to handle errors in the call_sgm functions
+  handle_call_sgm <- function(func, sgm, player_names, stat_counts, markets) {
+    tryCatch({
+      func(sgm, player_names, stat_counts, markets)
+    }, error = function(e) {
+      # Return a dataframe with NA values if an error occurs
+      data.frame(Selections=NA, Markets = NA, Unadjusted_Price=NA, Adjusted_Price=NA, Adjustment_Factor=NA, Agency=NA)
+    })
+  }
+
+  # Get individual dataframes
+  pointsbet_data <- handle_call_sgm(call_sgm_pointsbet, pointsbet_sgm, player_names, stat_counts, markets)
+  sportsbet_data <- handle_call_sgm(call_sgm_sportsbet, sportsbet_sgm, player_names, stat_counts, markets)
+  tab_data <- handle_call_sgm(call_sgm_tab, tab_sgm, player_names, stat_counts, markets)
+  betright_data <- handle_call_sgm(call_sgm_betright, betright_sgm, player_names, stat_counts, markets)
+  neds_data <- handle_call_sgm(call_sgm_neds, neds_sgm, player_names, stat_counts, markets)
+  bet365_data <- handle_call_sgm(call_sgm_bet365, bet365_sgm, player_names, stat_counts, markets)
+  dabble_data <- handle_call_sgm(call_sgm_dabble, dabble_sgm, player_names, stat_counts, markets)
+
+  # Bind together and return
+  bind_rows(pointsbet_data, sportsbet_data, tab_data, betright_data, neds_data, bet365_data, dabble_data) |>
+    mutate(Adjusted_Price = round(Adjusted_Price, 2),
+           Unadjusted_Price = round(Unadjusted_Price, 2),
+           Adjustment_Factor = round(Adjustment_Factor, 2)
+           ) |>
+    arrange(desc(Adjusted_Price))
+}
+
+# Compare CGM function
+compare_cgm <- function(player_names_cross, lines_cross, market_names_cross) {
+  # List of each agency data
+  all_data <- list(pointsbet_sgm, sportsbet_sgm, tab_sgm, betright_sgm, neds_sgm, bet365_sgm, dabble_sgm)
+
+  # Function to get cross game multi data
+  get_cgm <- function(data, player_names_cross, lines_cross, market_names_cross) {
+    if (length(player_names_cross) != length(lines_cross) || length(lines_cross) != length(market_names_cross)) {
+      stop("All lists should have the same length")
+    }
+
+    filtered_df <- data.frame()
+    for (i in seq_along(player_names_cross)) {
+      temp_df <- data %>%
+        filter(player_name == player_names_cross[i],
+               line == lines_cross[i],
+               market_name == market_names_cross[i])
+      filtered_df <- bind_rows(filtered_df, temp_df)
+    }
+
+    if (nrow(filtered_df) != length(player_names_cross)) {
+      return(NULL)
+    }
+
+    price <- prod(filtered_df$price)
+
+    combined_list <- paste(player_names_cross, lines_cross, sep = ": ")
+    player_string <- paste(combined_list, collapse = ", ")
+    market_string <- paste(market_names_cross, collapse = ", ")
+    match_string <- paste(filtered_df$match, collapse = ", ")
+
+    output_data <- data.frame(
+      Selections = player_string,
+      Matches = match_string,
+      Markets = market_string,
+      Price = round(price, 2),
+      Agency = first(data$agency)
+    )
+
+    return(output_data)
+  }
+
+  # Function to handle errors in the get_cgm function
+  handle_get_cgm <- function(data, player_names_cross, lines_cross, market_names_cross) {
+    tryCatch({
+      get_cgm(data, player_names_cross, lines_cross, market_names_cross)
+    }, error = function(e) {
+      # Return a dataframe with NA values if an error occurs
+      data.frame(Selections = NA, Matches = NA, Markets = NA, Price = NA, Agency = NA)
+    })
+  }
+
+  # Map over list of dataframes
+  cgm_all <- map_dfr(all_data, handle_get_cgm, player_names_cross, lines_cross, market_names_cross) %>%
+    arrange(desc(Price))
+
+  return(cgm_all)
+}
+
+# SGM data for display
+disposals_sgm <-
+  player_disposals_data |>
+  rename(price = over_price,
+         empirical_probability_2025 = empirical_prob_over_2025,
+         diff_2025 = diff_over_2025) |>
+  bind_rows(player_goals_data |> rename(price = over_price, empirical_probability_2025 = empirical_prob_over_2025, diff_2025 = diff_over_2025)) |>
+  bind_rows(player_marks_data |> rename(price = over_price, empirical_probability_2025 = empirical_prob_over_2025, diff_2025 = diff_over_2025)) |>
+  bind_rows(player_tackles_data |> rename(price = over_price, empirical_probability_2025 = empirical_prob_over_2025, diff_2025 = diff_over_2025)) |>
+  bind_rows(player_fantasy_data |> rename(price = over_price, empirical_probability_2025 = empirical_prob_over_2025, diff_2025 = diff_over_2025)) |>
+  bind_rows(player_kicks_data |> rename(price = over_price, empirical_probability_2025 = empirical_prob_over_2025, diff_2025 = diff_over_2025)) |>
+  bind_rows(player_handballs_data |> rename(price = over_price, empirical_probability_2025 = empirical_prob_over_2025, diff_2025 = diff_over_2025))
+
+# Create market best
+disposals_sgm <-
+  disposals_sgm |>
+  group_by(match, player_name, market_name, line) |>
+  arrange(desc(price), .by_group = TRUE) |>
+  mutate(
+    max_player_diff = max(diff_over_last_10, na.rm = TRUE),
+    second_best_price = if_else(n() >= 2, nth(price, 2), NA_real_),
+    market_best = row_number() == 1
+  ) |>
+  ungroup()
+
+# Unique matches for SGM
+matches <- matches_in_order
+
+# Unique agencies for SGM
+agencies_sgm <-
+  disposals_sgm |>
+  distinct(agency) |>
+  pull()
+
+# Add Dabble to the agencies list
+agencies_sgm <- c(agencies_sgm, "Dabble") |> unique()
+
+# Create disposals dataframe to display
+disposals_display <-
+  disposals_sgm |>
+  group_by(player_name, match, line, market_name) |>
+  mutate(
+    next_best_diff = if_else(market_best,
+                            ((1/second_best_price) - (1/price)),
+                             NA_real_)
+  ) |>
+  ungroup() |>
+  arrange(desc(max_player_diff)) |>
+  transmute(match,
+         player_name,
+         Position,
+         Matchup = DVP_Category,
+         market_name,
+         line,
+         price,
+         agency,
+         prob_2025 = round(empirical_probability_2025, 2),
+         diff_2025 = round(diff_2025, 2),
+         prob_last_10 = round(emp_prob_last_10, 2),
+         diff_last_10 = round(diff_over_last_10, 2),
+         next_best_diff = round(100 * next_best_diff, 1),
+         market_best)
+
+# Get correlations
+correlations_2024 <-
+  read_rds("../../Data/player_correlations_disposals_23.rds") |>
+  mutate_if(is.numeric, round, digits = 2)
 
 # Add home_away variable
 all_player_stats <-
@@ -860,6 +1041,128 @@ ui <- page_navbar(
       ),
       column(width = 8,
              card(card_body(plotOutput(outputId = "corr_plot_output", height = "800px", width = "100%")))
+      )
+    )
+  ),
+  nav_panel(
+    title = "SGM",
+    sidebarLayout(
+      sidebarPanel(
+        selectInput(
+          "match",
+          "Select Match",
+          choices = matches,
+          selected = NULL
+        ),
+        selectInput(
+          "agency_sgm",
+          "Select Agency",
+          choices = agencies_sgm,
+          selected = NULL
+        ),
+        selectInput(
+          "market",
+          "Select Market",
+          choices = c("Player Disposals", "Player Goals", "Player Marks", "Player Tackles", "Player Fantasy Points", "Player Kicks", "Player Handballs"),
+          selected = c("Player Disposals", "Player Goals", "Player Marks", "Player Tackles", "Player Fantasy Points", "Player Kicks", "Player Handballs"),
+          multiple = TRUE
+        ),
+        selectInput(
+          "matchup",
+          "Select Difficulty",
+          choices = c("Terrible", "Bad", "Neutral", "Good", "Excellent"),
+          selected = c("Terrible", "Bad", "Neutral", "Good", "Excellent"),
+          multiple = TRUE
+        ),
+        checkboxInput("best_odds", "Only Show Best Market Odds?", value = FALSE),
+        h3("Selections"),
+        DT::dataTableOutput("selected"),
+        h3("Pairwise Correlations"),
+        DT::dataTableOutput("correlations"),
+        h3("SGM Information"),
+        uiOutput("summary"),
+        h3("Odds Comparison"),
+        actionButton("get_comparison", label = "Compare Odds"),
+        actionButton("clear_comparison", label = "Clear Selections"),
+        DT::dataTableOutput("odds_compare")
+      ),
+
+      mainPanel(
+        tabsetPanel(
+          tabPanel("Player List",
+                   DT::dataTableOutput("table")
+          )
+        )
+      )
+    )
+  ),
+  nav_panel(
+    title = "Cross Game Multi",
+    sidebarLayout(
+      sidebarPanel(
+        selectInput(
+          "agency_cross",
+          "Select Agency",
+          choices = agencies_sgm,
+          selected = NULL
+        ),
+        selectInput(
+          "market_cross",
+          "Select Market",
+          choices = c("Player Disposals", "Player Goals", "Player Marks", "Player Tackles", "Player Fantasy Points", "Player Kicks", "Player Handballs"),
+          selected = c("Player Disposals", "Player Goals", "Player Marks", "Player Tackles", "Player Fantasy Points", "Player Kicks", "Player Handballs"),
+          multiple = TRUE
+        ),
+        selectInput(
+          "matchup_cross",
+          "Select Difficulty",
+          choices = c("Terrible", "Bad", "Neutral", "Good", "Excellent"),
+          selected = c("Terrible", "Bad", "Neutral", "Good", "Excellent"),
+          multiple = TRUE
+        ),
+        checkboxInput("best_odds_cross", "Only Show Best Market Odds?", value = FALSE),
+        h3("Selections"),
+        DT::dataTableOutput("selected_cross"),
+        h3("Multi Information"),
+        uiOutput("summary_cross"),
+        actionButton("get_comparison_cross", label = "Compare Odds"),
+        actionButton("clear_comparison_cross", label = "Clear Selections"),
+        DT::dataTableOutput("odds_compare_cross")
+      ),
+
+      mainPanel(
+        DT::dataTableOutput("table_cross")
+      )
+    )
+  ),
+  nav_panel(
+    title = "Player Combos",
+    sidebarLayout(
+      sidebarPanel(
+        selectInput(
+          "match_combos",
+          "Select Match",
+          choices = matches,
+          selected = NULL
+        ),
+        selectInput(
+          "market_filter",
+          "Filter by Market",
+          choices = c("All", "Player Disposals", "Player Goals", "Player Marks", "Player Tackles", "Player Fantasy Points", "Player Kicks", "Player Handballs"),
+          selected = "All"
+        ),
+        sliderInput(
+          "price_range",
+          "Price Range",
+          min = 1,
+          max = 1000,
+          value = c(1, 1000)
+        ),
+        actionButton("get_combos", "Get Combinations")
+      ),
+      mainPanel(
+        uiOutput("player_selection_ui"),
+        DT::dataTableOutput("combos_table")
       )
     )
   )
@@ -2031,10 +2334,10 @@ output$venue_specific_table <- renderDT({
   #=============================================================================
   # Player Correlations
   #=============================================================================
-  
+
   output$corr_plot_output <- renderPlot({
     req(input$player_name_corr, input$teammate_name_corr, input$season_input_corr, input$metric_input_corr_b, input$metric_input_corr_a)
-    
+
     plot <-
       get_player_correlation(
         data = filtered_player_stats_2,
@@ -2046,8 +2349,324 @@ output$venue_specific_table <- renderDT({
         line_a = input$line_input_corr_a,
         line_b = input$line_input_corr_b
       )
-    
+
     return(plot)
+  })
+
+  #=============================================================================
+  # SGM Tab Server Logic
+  #=============================================================================
+
+  # For the "SGM" panel
+  output$table <- renderDT({
+    filtered_data <-
+      disposals_display[disposals_display$match == input$match &
+                          disposals_display$agency == input$agency_sgm &
+                          disposals_display$Matchup %in% input$matchup &
+                          disposals_display$market_name %in% input$market,]
+
+    # Filter for Dabble's specific price requirement in the Player List
+    if (input$agency_sgm == "Dabble") {
+      filtered_data <- filtered_data |> filter(price == 1.79)
+    }
+
+    if (input$best_odds) {
+      filtered_data <- filtered_data |>
+        filter(market_best) |>
+        select(-market_best)
+    } else {
+      filtered_data <- filtered_data |> select(-next_best_diff)
+    }
+
+    datatable(filtered_data, selection = "multiple", filter = "top")
+  }, server = FALSE)
+
+  observeEvent(input$table_rows_selected,{
+    output$selected <- renderDT({
+      if(!is.null(input$table_rows_selected)){
+        filtered_data <-
+          disposals_display[disposals_display$match == input$match &
+                              disposals_display$agency == input$agency_sgm &
+                              disposals_display$Matchup %in% input$matchup &
+                              disposals_display$market_name %in% input$market,]
+
+        # Filter for Dabble's specific price requirement
+        if (input$agency_sgm == "Dabble") {
+          filtered_data <- filtered_data |> filter(price == 1.79)
+        }
+
+        if (input$best_odds) {filtered_data <- filtered_data |> filter(market_best) |> select(-market_best)}
+        selected_data <- filtered_data[input$table_rows_selected, c("player_name", "line", "market_name", "price")]
+        datatable(selected_data)
+      }
+    })
+  })
+
+  # Get the table proxy
+  proxy <- dataTableProxy("table")
+
+  # Get the table proxy for the cross game multi
+  proxy_cross <- dataTableProxy("table_cross")
+
+  output$correlations <- renderDT({
+    filtered_data <- disposals_display[disposals_display$match == input$match & disposals_display$agency == input$agency_sgm,]
+
+    # Filter for Dabble's specific price requirement
+    if (input$agency_sgm == "Dabble") {
+      filtered_data <- filtered_data |> filter(price == 1.79)
+    }
+
+    if (input$best_odds) {filtered_data <- filtered_data |> filter(market_best) |> select(-market_best)}
+    selected_data <- filtered_data[input$table_rows_selected, c("player_name", "line", "market_name", "price")]
+
+    correlations_table <- correlations_2024 |> filter(player_a %in% selected_data$player_name & player_b %in% selected_data$player_name)
+    datatable(correlations_table)
+  })
+
+  # SGM Comparison
+  observeEvent(input$get_comparison, {
+    # Get selected data
+    filtered_data <- disposals_display[disposals_display$match == input$match &
+                                         disposals_display$agency == input$agency_sgm &
+                                         disposals_display$Matchup %in% input$matchup &
+                                         disposals_display$market_name %in% input$market,]
+
+    # Filter for Dabble's specific price requirement
+    if (input$agency_sgm == "Dabble") {
+      filtered_data <- filtered_data |> filter(price == 1.79)
+    }
+
+    if (input$best_odds) {filtered_data <- filtered_data |> filter(market_best) |> select(-market_best)}
+    selected_data <- filtered_data[input$table_rows_selected, c("player_name", "line", "market_name", "price")]
+
+    player_names = selected_data$player_name
+    lines = selected_data$line
+    market_names = selected_data$market_name
+
+    # Call function
+    comparison_df <- compare_sgm(
+      player_names = player_names,
+      stat_counts = lines,
+      markets = market_names)
+
+    # populate DTOutput
+    output$odds_compare <- renderDT({
+      datatable(comparison_df)
+    })
+  })
+
+  # Observe the click event on the "clear_rows" button
+  observeEvent(input$clear_comparison, {
+    # Deselect all rows in the table
+    selectRows(proxy, NULL)
+  })
+
+  observeEvent(input$clear_comparison_cross, {
+    # Deselect all rows in the table
+    selectRows(proxy_cross, NULL)
+  })
+
+  output$summary <- renderUI({
+    if(!is.null(input$table_rows_selected)){
+      filtered_data <- disposals_display[disposals_display$match == input$match &
+                                           disposals_display$agency == input$agency_sgm &
+                                           disposals_display$Matchup %in% input$matchup &
+                                           disposals_display$market_name %in% input$market,]
+
+      # Filter for Dabble's specific price requirement
+      if (input$agency_sgm == "Dabble") {
+        filtered_data <- filtered_data |> filter(price == 1.79)
+      }
+
+      if (input$best_odds) {filtered_data <- filtered_data |> filter(market_best) |> select(-market_best)}
+      selected_data <- filtered_data[input$table_rows_selected, ]
+      uncorrelated_price <- prod(selected_data$price)
+      empirical_price <- 1 / prod(selected_data$prob_last_10)
+      HTML(paste0("<strong>Uncorrelated Price:</strong>", " $", round(uncorrelated_price, 2), "<br/>",
+                  " <strong>Theoretical Uncorrelated Price:</strong>", " $", round(empirical_price, 2)))
+    }
+  })
+
+  #=============================================================================
+  # Cross Game Multi Tab Server Logic
+  #=============================================================================
+
+  # For the "Cross Game Multi" panel
+  output$table_cross <- renderDT({
+    filtered_data_cross <- disposals_display[disposals_display$agency == input$agency_cross &
+                                               disposals_display$Matchup %in% input$matchup_cross &
+                                             disposals_display$market_name %in% input$market_cross,]
+
+    if (input$best_odds_cross) {filtered_data_cross <- filtered_data_cross |> filter(market_best) |> select(-market_best)}
+
+    datatable(filtered_data_cross, selection = "multiple", filter = "top")
+  }, server = FALSE)
+
+  observeEvent(input$table_cross_rows_selected,{
+    output$selected_cross <- renderDT({
+      if(!is.null(input$table_cross_rows_selected)){
+        filtered_data_cross <- disposals_display[disposals_display$agency == input$agency_cross &
+                                                 disposals_display$Matchup %in% input$matchup_cross &
+                                                 disposals_display$market_name %in% input$market_cross,]
+
+        if (input$best_odds_cross) {filtered_data_cross <- filtered_data_cross |> filter(market_best) |> select(-market_best)}
+
+        selected_data_cross <- filtered_data_cross[input$table_cross_rows_selected, c("player_name", "line", "market_name", "price")]
+        datatable(selected_data_cross)
+      }
+    })
+  })
+
+  # Cross Game Comparison
+  observeEvent(input$get_comparison_cross, {
+    # Get selected data
+    filtered_data_cross <- disposals_display[disposals_display$agency == input$agency_cross &
+                                               disposals_display$Matchup %in% input$matchup_cross &
+                                               disposals_display$market_name %in% input$market_cross,]
+
+    if (input$best_odds_cross) {filtered_data_cross <- filtered_data_cross |> filter(market_best) |> select(-market_best)}
+
+    selected_data_cross <- filtered_data_cross[input$table_cross_rows_selected, c("player_name", "line", "market_name", "price", "agency")]
+
+    player_names_cross = selected_data_cross$player_name
+    lines_cross = selected_data_cross$line
+    market_names_cross = selected_data_cross$market_name
+
+    # Call function
+    comparison_df_cross <-
+      compare_cgm(market_names_cross = market_names_cross,
+                  player_names_cross = player_names_cross,
+                  lines_cross = lines_cross)
+
+    # populate DTOutput
+    output$odds_compare_cross <- renderDT({
+      datatable(comparison_df_cross)
+    })
+  })
+
+  output$summary_cross <- renderUI({
+    if(!is.null(input$table_cross_rows_selected)){
+      filtered_data_cross <- disposals_display[disposals_display$agency == input$agency_cross &
+                                               disposals_display$Matchup %in% input$matchup_cross &
+                                               disposals_display$market_name %in% input$market_cross,]
+
+      if (input$best_odds_cross) {filtered_data_cross <- filtered_data_cross |> filter(market_best) |> select(-market_best)}
+
+      selected_data_cross <- filtered_data_cross[input$table_cross_rows_selected, ]
+      uncorrelated_price_cross <- prod(selected_data_cross$price)
+      empirical_price_cross <- 1 / prod(selected_data_cross$prob_2025)
+      empirical_price_cross_l10 <- 1 / prod(selected_data_cross$prob_last_10)
+      diff = 1/empirical_price_cross - 1/uncorrelated_price_cross
+      diff_l10 = 1/empirical_price_cross_l10 - 1/uncorrelated_price_cross
+      HTML(paste0("<strong>Multi Price:</strong>", " $", round(uncorrelated_price_cross, 2), "<br/>",
+                  " <strong>Theoretical Multi Price:</strong>", " $", round(empirical_price_cross, 2), "<br/>",
+                  " <strong>Edge L10:</strong>", " ", round(100*diff_l10, 3), "%"), "<br/>",
+                  " <strong>Edge 2025:</strong>", " ", round(100*diff, 3), "%")
+    }
+  })
+
+  #=============================================================================
+  # Player Combos Tab Server Logic
+  #=============================================================================
+
+  # For the "Player Combos" panel
+  output$player_selection_ui <- renderUI({
+    DT::dataTableOutput("player_table_combos")
+  })
+
+  output$player_table_combos <- renderDT({
+    filtered_data <- disposals_display |>
+      filter(match == input$match_combos) |>
+      distinct(player_name, .keep_all = TRUE) |>
+      select(player_name, Position, Matchup)
+
+    datatable(filtered_data, selection = 'multiple', options = list(pageLength = 10))
+  })
+
+  observeEvent(input$get_combos, {
+
+    # Get selected players
+    selected_rows <- input$player_table_combos_rows_selected
+
+    if (is.null(selected_rows) || length(selected_rows) < 2 || length(selected_rows) > 3) {
+      output$combos_table <- renderDT({
+        datatable(data.frame(Message = "Please select 2 or 3 players."))
+      })
+      return()
+    }
+
+    filtered_data <- disposals_display |>
+      filter(match == input$match_combos) |>
+      distinct(player_name, .keep_all = TRUE) |>
+      select(player_name, Position, Matchup)
+
+    selected_players <- filtered_data[selected_rows, ]$player_name
+
+    # Get market filter
+    market_filter <- if (input$market_filter == "All") NULL else input$market_filter
+
+    # Get player data
+    player_data <- disposals_display |>
+      filter(match == input$match_combos)
+
+    # Get combos
+    combos_df <- get_player_combos(player_data, selected_players, market_filter)
+
+    # Filter by price range
+    if (nrow(combos_df) > 0 && "Message" %notin% names(combos_df)) {
+      # Find agency columns - they are the ones that are not Match or Selections
+      agency_cols <- setdiff(names(combos_df), c("Match", "Selections"))
+
+      # Get max price across all agencies
+      combos_df$max_price <- do.call(pmax, c(combos_df[agency_cols], na.rm = TRUE))
+
+      combos_df <- combos_df |>
+        filter(max_price >= input$price_range[1] & max_price <= input$price_range[2]) |>
+        select(-max_price)
+    }
+
+    # Display table
+    output$combos_table <- renderDT({
+      if (nrow(combos_df) > 0 && "Message" %notin% names(combos_df)) {
+        agency_cols <- setdiff(names(combos_df), c("Match", "Selections"))
+        agency_indices <- which(names(combos_df) %in% agency_cols)
+
+        datatable(
+          combos_df,
+          escape = FALSE,
+          options = list(
+            pageLength = 10,
+            columnDefs = list(list(targets = 1, render = JS(
+              "function(data, type, row, meta){",
+              "  if(type === 'display'){ return data.replace(/, /g, '<br/>'); }",
+              "  return data;",
+              "}"
+            ))),
+            rowCallback = JS(
+              "function(row, data) {",
+              sprintf("var agency_indices = [%s];", paste(agency_indices, collapse = ",")),
+              "var prices = [];",
+              "agency_indices.forEach(function(i) {",
+              "  var price = parseFloat(data[i-1]);",
+              "  if (!isNaN(price)) { prices.push(price); }",
+              "});",
+              "if (prices.length > 0) {",
+              "  var max_price = Math.max.apply(null, prices);",
+              "  agency_indices.forEach(function(i) {",
+              "    var cell_value = parseFloat(data[i-1]);",
+              "    if (cell_value === max_price) {",
+              "      $('td', row).eq(i-1).css('background-color', 'rgba(144, 238, 144, 0.5)');",
+              "    }",
+              "  });",
+              "}",
+              "}"
+            )
+          )
+        )
+      } else {
+        datatable(combos_df)
+      }
+    })
   })
 }
 

--- a/Apps/AFL_APP/bet365_sgm.R
+++ b/Apps/AFL_APP/bet365_sgm.R
@@ -1,0 +1,66 @@
+library(httr)
+library(jsonlite)
+library(tidyverse)
+library(purrr)
+
+
+# Bet365 SGM-----------------------------------------------------------------
+bet365_sgm <-
+  read_csv("../../Data/scraped_odds/bet365_player_disposals.csv") |> 
+  bind_rows(read_csv("../../Data/scraped_odds/bet365_player_goals.csv")) |> 
+  rename(price = over_price) |>
+  distinct(match, player_name, line, market_name, agency, .keep_all = TRUE) |> 
+  select(-contains("under"))
+
+
+#===============================================================================
+# Function to get SGM Price
+#===============================================================================
+
+call_sgm_bet365 <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>%
+      filter(player_name == player_names[i],
+             line == stat_counts[i],
+             market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  if (nrow(filtered_df) != length(player_names)) {
+    return(NULL)
+  }
+  
+  unadjusted_price <- prod(filtered_df$price)
+  
+  adjusted_price = 1/(0.004 + (1/unadjusted_price)) |> round(2)
+  
+  adjustment_factor <- adjusted_price / unadjusted_price
+  
+  combined_list <- paste(player_names, stat_counts, sep = ": ")
+  player_string <- paste(combined_list, collapse = ", ")
+  market_string <- paste(markets, collapse = ", ")
+  
+  output_data <- data.frame(
+    Selections = player_string,
+    Markets = market_string,
+    Unadjusted_Price = round(unadjusted_price, 2),
+    Adjusted_Price = round(adjusted_price, 2),
+    Adjustment_Factor = adjustment_factor,
+    Agency = 'Bet365'
+  )
+  
+  return(output_data)
+  
+}
+
+# call_sgm_bet365(
+#   data = bet365_sgm,
+#   player_names = c("Charlie Curnow", "Blake Acres"),
+#   stat_counts = c(2.5, 19.5),
+#   markets = c("Player Goals", "Player Disposals")
+# )

--- a/Apps/AFL_APP/betright_sgm.R
+++ b/Apps/AFL_APP/betright_sgm.R
@@ -1,0 +1,141 @@
+library(httr)
+library(jsonlite)
+library(tidyverse)
+library(purrr)
+
+# BetRight SGM------------------------------------------------------------------
+betright_sgm_list <- list(
+  read_csv("../../Data/scraped_odds/betright_player_disposals.csv"),
+  read_csv("../../Data/scraped_odds/betright_player_goals.csv"),
+  read_csv("../../Data/scraped_odds/betright_player_tackles.csv"),
+  read_csv("../../Data/scraped_odds/betright_player_marks.csv"),
+  read_csv("../../Data/scraped_odds/betright_player_fantasy_points.csv")
+)
+
+betright_sgm <-
+  betright_sgm_list |> 
+  keep(~nrow(.x) > 0) |>
+  bind_rows() |> 
+  rename(price = over_price) |> 
+  distinct(match, player_name, line, market_name, agency, .keep_all = TRUE) |> 
+  select(-contains("under"))
+
+#===============================================================================
+# Function to get SGM data
+#===============================================================================
+
+# Function to get SGM data
+get_sgm_betright <- function(data, player_names, stat_counts, markets) {
+  
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in 1:length(player_names)) {
+    temp_df <- data[data$player_name == player_names[i] & 
+                      data$line == stat_counts[i] &
+                      data$market_name == markets[i], ]
+    if (nrow(temp_df) == 0) {
+      stop(paste("No data found for", player_names[i], "with", stat_counts[i], "disposals."))
+    }
+    filtered_df <- rbind(filtered_df, temp_df)
+  }
+  
+  header <- filtered_df$group_by_header
+  event_id <- filtered_df$event_id
+  outcome_name <- filtered_df$outcome_name
+  outcome_id <- filtered_df$outcome_id
+  fixed_market_id <- filtered_df$fixed_market_id
+  points <- "0"
+  fixed_win <- filtered_df$price
+  
+  payload <- lapply(1:length(player_names), function(i) {
+    list(
+      eventId = unlist(event_id[i]),
+      outcomeId = unlist(outcome_id[i]),
+      marketType = "WIN",
+      fixedWin = unlist(fixed_win[i]),
+      fixedMarketId = unlist(fixed_market_id[i]),
+      marketTypeDesc = "Win",
+      groupByHeader = header[i],
+      points = points,
+      outcomeName = outcome_name[i]
+    )
+  })
+  
+  return(payload)
+}
+
+
+#==============================================================================
+# Make Post Request
+#==============================================================================
+
+# Make POST request
+call_sgm_betright <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in 1:length(player_names)) {
+    temp_df <- data[data$player_name == player_names[i] & 
+                      data$line == stat_counts[i] &
+                      data$market_name == markets[i], ]
+    if (nrow(temp_df) == 0) {
+      stop(paste("No data found for", player_names[i], "with", stat_counts[i], "disposals."))
+    }
+    filtered_df <- rbind(filtered_df, temp_df)
+  }
+  
+  if (nrow(filtered_df) != length(player_names)) {
+    return(NULL)
+  }
+  
+  unadjusted_price <- prod(filtered_df$price)
+  
+  payload <- get_sgm_betright(data, player_names, stat_counts, markets)
+  
+  url <- "https://sgm-api.betright.com.au/Pricing/SgmPrice?"
+  
+  headers <- add_headers('User-Agent' = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Mobile Safari/537.36',
+                         'Content-Type' = 'application/json;charset=UTF-8',
+                         'Origin' = 'https://betright.com.au',
+                         'Referer' = 'https://betright.com.au/')
+  
+  response <- POST(url, headers, body = toJSON(payload, auto_unbox = TRUE))
+  
+  if (http_error(response)) {
+    stop("HTTP error occurred while calling API.")
+  }
+  
+  response_content <- fromJSON(content(response, "text"))
+  
+  if (!"price" %in% names(response_content)) {
+    stop("No price information found in the API response.")
+  }
+  
+  adjusted_price <- as.numeric(response_content$price)
+  adjustment_factor <- adjusted_price / unadjusted_price
+  player_string <- paste(paste(player_names, stat_counts, sep = ": "), collapse = ", ")
+  market_string <- paste(markets, collapse = ", ")
+  
+  output_data <- data.frame(
+    Selections = player_string,
+    Markets = market_string,
+    Unadjusted_Price = unadjusted_price,
+    Adjusted_Price = adjusted_price,
+    Adjustment_Factor = adjustment_factor,
+    Agency = 'Betright'
+  )
+  
+  return(output_data)
+}
+
+# call_sgm_betright(
+#   data = betright_sgm,
+#   player_names = c("James Jordon", "Joe Daniher"),
+#   stat_counts = c(14.5, 14.5),
+#   markets = c("Player Disposals", "Player Disposals")
+# )

--- a/Apps/AFL_APP/dabble_sgm.R
+++ b/Apps/AFL_APP/dabble_sgm.R
@@ -1,0 +1,81 @@
+library(httr)
+library(jsonlite)
+library(tidyverse)
+library(purrr)
+
+# Dabble SGM-----------------------------------------------------------------
+
+# Helper function to read CSV and return empty tibble if 0 rows
+safe_read <- function(file) {
+  if (!file.exists(file)) return(tibble())
+  df <- read_csv(file, show_col_types = FALSE)
+  if (nrow(df) == 0) return(tibble()) else return(df)
+}
+
+dabble_sgm <-
+  safe_read("../../Data/scraped_odds/dabble_player_disposals.csv") |> 
+  bind_rows(safe_read("../../Data/scraped_odds/dabble_player_goals.csv")) |> 
+  bind_rows(safe_read("../../Data/scraped_odds/dabble_player_fantasy_points.csv")) |>
+  bind_rows(safe_read("../../Data/scraped_odds/dabble_player_tackles.csv")) |>
+  bind_rows(safe_read("../../Data/scraped_odds/dabble_player_marks.csv")) |>
+  rename(price = over_price) |> 
+  distinct(match, player_name, line, market_name, agency, .keep_all = TRUE) |> 
+  select(-contains("under")) |> 
+  filter(price == 1.79)
+
+#===============================================================================
+# Function to get SGM Price
+#===============================================================================
+
+call_sgm_dabble <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>%
+      filter(player_name == player_names[i],
+             line == stat_counts[i],
+             market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  if (nrow(filtered_df) != length(player_names)) {
+    return(NULL)
+  }
+  
+  # Filter to only include markets with a price of 1.79
+  filtered_df <- filtered_df |> 
+    filter(price == 1.79)
+  
+  # If no markets are left after filtering, return NULL
+  if (nrow(filtered_df) == 0) {
+    return(NULL)
+  }
+  
+  # Calculate adjusted price
+  adjusted_price <- prod(filtered_df$price)
+  
+  # Unadjusted price is the same as adjusted price for Dabble
+  unadjusted_price <- adjusted_price
+  
+  # Adjustment factor is 1
+  adjustment_factor <- 1
+  
+  combined_list <- paste(player_names, stat_counts, sep = ": ")
+  player_string <- paste(combined_list, collapse = ", ")
+  market_string <- paste(markets, collapse = ", ")
+  
+  output_data <- data.frame(
+    Selections = player_string,
+    Markets = market_string,
+    Unadjusted_Price = unadjusted_price,
+    Adjusted_Price = adjusted_price,
+    Adjustment_Factor = adjustment_factor,
+    Agency = 'Dabble'
+  )
+  
+  return(output_data)
+  
+}

--- a/Apps/AFL_APP/neds_sgm.R
+++ b/Apps/AFL_APP/neds_sgm.R
@@ -1,0 +1,113 @@
+library(httr)
+library(jsonlite)
+library(tidyverse)
+library(purrr)
+
+
+# Neds SGM-----------------------------------------------------------------
+neds_sgm <-
+  read_csv("../../Data/scraped_odds/neds_player_disposals.csv") |> 
+  bind_rows(read_csv("../../Data/scraped_odds/neds_player_goals.csv")) |> 
+  bind_rows(read_csv("../../Data/scraped_odds/neds_player_fantasy_points.csv")) |>
+  rename(price = over_price) |> 
+  distinct(match, player_name, line, market_name, agency, .keep_all = TRUE) |> 
+  select(-contains("under"))
+
+#===============================================================================
+# Function to get API URL
+#===============================================================================
+
+create_api_url <- function(event_id, market_ids, entrant_ids) {
+  # Base URL for the API endpoint
+  base_url <- "https://api.neds.com.au/v2/same-game-multi/get-odds"
+  
+  # Start constructing the `same_game_multies` parameter
+  same_game_multies <- sprintf('{"%s":{"event_id":"%s","selections":[', event_id, event_id)
+  
+  # Add each market and entrant pair to the selections
+  selections <- vector("list", length = length(market_ids))
+  for (i in seq_along(market_ids)) {
+    selections[[i]] <- sprintf('{"market_id":"%s","entrant_id":"%s"}', market_ids[i], entrant_ids[i])
+  }
+  
+  # Combine selections into a single string
+  selections_str <- paste(selections, collapse = ",")
+  
+  # Complete the construction of the `same_game_multies` parameter
+  same_game_multies <- paste0(same_game_multies, selections_str, "]}}")
+  
+  # URL-encode the `same_game_multies` parameter
+  encoded_same_game_multies <- URLencode(same_game_multies)
+  
+  # Construct the full URL
+  full_url <- sprintf('%s?same_game_multies=%s', base_url, encoded_same_game_multies)
+  
+  return(full_url)
+}
+
+#===============================================================================
+# Function to get SGM Price
+#===============================================================================
+
+call_sgm_neds <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>%
+      filter(player_name == player_names[i],
+             line == stat_counts[i],
+             market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  if (nrow(filtered_df) != length(player_names)) {
+    return(NULL)
+  }
+  
+  # Use Filtered DF to get the API URL
+  event_id <- filtered_df$event_id[1]
+  market_ids <- filtered_df$market_id
+  entrant_ids <- filtered_df$entrant_id
+  
+  neds_sgm_url <- create_api_url(event_id, market_ids, entrant_ids)
+  
+  # Call the API
+  response <-
+    httr::GET(neds_sgm_url,httr::add_headers(`Content-Type` = "application/json")) %>%
+    httr::content("parsed")
+  
+  denominator <- response$prices[[1]]$odds$denominator
+  numerator <- response$prices[[1]]$odds$numerator
+  
+  adjusted_price = (numerator / denominator) + 1
+  
+  unadjusted_price <- prod(filtered_df$price)
+  
+  adjustment_factor <- adjusted_price / unadjusted_price
+  
+  combined_list <- paste(player_names, stat_counts, sep = ": ")
+  player_string <- paste(combined_list, collapse = ", ")
+  market_string <- paste(markets, collapse = ", ")
+  
+  output_data <- data.frame(
+    Selections = player_string,
+    Markets = market_string,
+    Unadjusted_Price = unadjusted_price,
+    Adjusted_Price = adjusted_price,
+    Adjustment_Factor = adjustment_factor,
+    Agency = 'Neds'
+  )
+  
+  return(output_data)
+  
+}
+
+# call_sgm_neds(
+#   data = neds_sgm,
+#   player_names = c("Charlie Curnow", "Blake Acres"),
+#   stat_counts = c(2.5, 19.5),
+#   markets = c("Player Goals", "Player Disposals")
+# )

--- a/Apps/AFL_APP/palmerbet_sgm.R
+++ b/Apps/AFL_APP/palmerbet_sgm.R
@@ -1,0 +1,122 @@
+library(httr)
+library(jsonlite)
+library(dplyr)
+library(purrr)
+library(mongolite)
+uri <- Sys.getenv("mongodb_connection_string")
+
+# Palmerbet SGM-----------------------------------------------------------------
+palmersgm_con <- mongo(collection = "Palmerbet-SGM", db = "Odds", url = uri)
+palmerbet_sgm <- palmersgm_con$find('{}') |> tibble() |> mutate(number_of_disposals = str_extract(market, "[0-9]{1,2}")) |> mutate(number_of_disposals = paste0(number_of_disposals, "+"))
+
+#===============================================================================
+# Function to get SGM data
+#=-=============================================================================
+
+# Create function to call the API
+get_sgm_palmerbet <- function(data, player_names, disposal_counts) {
+  if (length(player_names) != length(disposal_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>% 
+      filter(player == player_names[[i]] &
+               number_of_disposals == disposal_counts[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  market_ids <- unique(as.character(filtered_df$market_id))
+  
+  selected_markets <- lapply(market_ids, function(market_id) {
+    market_data <- filtered_df %>% 
+      filter(market_id == !!market_id)
+    
+    id_list <- as.character(market_data$outcome_id)
+    price_list <- as.numeric(market_data$price)
+    market_name <- as.character(market_data$market[1])  # assuming the market name is consistent for all outcomes within a market
+    
+    outcomes <- lapply(1:length(id_list), function(i) 
+      list(price = unbox(price_list[i]), title = unbox(id_list[i]))
+    )
+    
+    list(
+      id = unbox(market_id),
+      name = unbox(market_name),
+      outcomes = outcomes
+    )
+  })
+  
+  selected_legs <- lapply(1:length(filtered_df$outcome_id), function(i) 
+    list(marketId = unbox(filtered_df$market_id[i]), title = unbox(filtered_df$outcome_id[i]))
+  )
+  
+  payload <- list(
+    markets = selected_markets,
+    legs = selected_legs
+  )
+  
+  return(payload)
+}
+
+
+#==============================================================================
+# Make Post Request
+#==============================================================================
+
+call_sgm_palmerbet <- function(data, player_names, disposal_counts) {
+  if (length(player_names) != length(disposal_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>% 
+      filter(player == player_names[i],
+             number_of_disposals == disposal_counts[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  unadjusted_price <- prod(filtered_df$price)
+  
+  payload <- get_sgm_palmerbet(data, player_names, disposal_counts)
+  
+  url <- 'https://pricing.palmerbet.online:9698/AustralianRules/price?channel=website'
+  
+  headers <- c('User-Agent' = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Mobile Safari/537.36',
+               'Content-Type' = 'application/json;charset=UTF-8',
+               'Origin' = 'https://www.palmerbet.com/',
+               'Referer' = 'https://www.palmerbet.com/')
+  
+  # Error handling for the POST request
+  tryCatch({
+    response <- POST(url, body = toJSON(payload), add_headers(.headers = headers), encode = "json")
+  }, error = function(e) {
+    message("Error in POST request: ", e)
+    return(NULL)
+  })
+  
+  # If there is no response, return NULL
+  if (is.null(response)) {
+    return(NULL)
+  }
+  
+  response_content <- content(response, "parsed")
+  
+  # Assuming the structure of response is similar to the pointsbet one 
+  adjusted_price <- as.numeric(response_content$price)
+  adjustment_factor <- adjusted_price / unadjusted_price
+  combined_list <- paste(player_names, disposal_counts, sep = ": ")
+  player_string <- paste(combined_list, collapse = ", ")
+  
+  output_data <- data.frame(
+    Selections = player_string,
+    Unadjusted_Price = unadjusted_price,
+    Adjusted_Price = adjusted_price,
+    Adjustment_Factor = adjustment_factor,
+    Agency = 'Palmerbet'
+  )
+  
+  return(output_data)
+}

--- a/Apps/AFL_APP/player_combos.R
+++ b/Apps/AFL_APP/player_combos.R
@@ -1,0 +1,106 @@
+
+# Function to get all market combinations for 2 or 3 players from the same match
+get_player_combos <- function(player_data, selected_players, market_filter = NULL) {
+
+  num_players <- length(selected_players)
+  if (num_players < 2 || num_players > 3) {
+    return(data.frame(Message = "Please select 2 or 3 players."))
+  }
+
+  # Optional: filter by market
+  if (!is.null(market_filter) && market_filter != "All") {
+    player_data <- player_data |>
+      filter(market_name == market_filter)
+  }
+
+  # Get all agencies that have markets for all selected players in the given match
+  agencies_with_all_players <- player_data |>
+    filter(player_name %in% selected_players) |>
+    group_by(agency) |>
+    filter(n_distinct(player_name) == num_players) |>
+    distinct(agency) |>
+    pull(agency)
+
+  # Function to get combos for a single agency
+  get_combos_by_agency <- function(agency_name, data, current_players) {
+    agency_data <- data |> filter(agency == agency_name)
+
+    # Get markets for each player
+    player_markets_list <- lapply(current_players, function(p) {
+      agency_data |> filter(player_name == p)
+    })
+
+    # If any player has no markets for this agency, return NULL
+    if (any(sapply(player_markets_list, nrow) == 0)) {
+        return(NULL)
+    }
+
+    # Create a list of row indices for expand.grid
+    grid_indices <- lapply(player_markets_list, function(df) 1:nrow(df))
+    names(grid_indices) <- paste0("p", 1:length(current_players), "_row")
+
+    # Create all combinations of markets using row indices
+    all_combos_indices <- do.call(expand.grid, grid_indices)
+
+    # If no combos, return NULL
+    if (nrow(all_combos_indices) == 0) {
+        return(NULL)
+    }
+
+    # Calculate prices and create selection strings for each combo
+    selection_details <- lapply(1:nrow(all_combos_indices), function(i) {
+      combo_row <- all_combos_indices[i, ]
+      prices <- c()
+      selections <- c()
+
+      for (j in 1:length(current_players)) {
+        player_market_data <- player_markets_list[[j]]
+        market_row_index <- combo_row[[j]]
+        
+        prices <- c(prices, player_market_data$price[market_row_index])
+        selections <- c(selections,
+          paste(
+            current_players[j], "-",
+            player_market_data$market_name[market_row_index],
+            player_market_data$line[market_row_index]
+          )
+        )
+      }
+      
+      data.frame(
+        Selections = paste(selections, collapse = ", "),
+        Multi_Price = round(prod(prices), 2)
+      )
+    })
+
+    combos_with_data <- bind_rows(selection_details)
+    combos_with_data$Agency <- agency_name
+    combos_with_data$Match <- player_markets_list[[1]]$match[1] # Get match from first player
+
+    # Reorder columns
+    combos_with_data <- combos_with_data |>
+        select(Match, Agency, Selections, Multi_Price)
+
+    return(combos_with_data)
+  }
+
+  # Map over the agencies to get all combinations
+  all_agency_combos <- map_dfr(agencies_with_all_players, get_combos_by_agency, data = player_data, current_players = selected_players)
+
+  # If no combos, return a message
+  if (nrow(all_agency_combos) == 0) {
+    return(data.frame(Message = "No combinations found for the selected players and market."))
+  }
+
+  # Pivot to wide format, resolving duplicates by taking the max price
+  wide_combos <- all_agency_combos |>
+    pivot_wider(
+      names_from = Agency,
+      values_from = Multi_Price,
+      id_cols = c(Match, Selections),
+      values_fn = max, # Use max to resolve duplicates
+      values_fill = NA # Still fill with NA if no value
+    )
+
+  return(wide_combos)
+}

--- a/Apps/AFL_APP/pointsbet_sgm.R
+++ b/Apps/AFL_APP/pointsbet_sgm.R
@@ -1,0 +1,131 @@
+library(httr)
+library(jsonlite)
+library(dplyr)
+library(purrr)
+library(mongolite)
+library(tidyverse)
+
+# Pointsbet SGM-----------------------------------------------------------------
+pointsbet_sgm_list <-
+  list(
+    read_csv("../../Data/scraped_odds/pointsbet_player_disposals.csv"),
+    read_csv("../../Data/scraped_odds/pointsbet_player_fantasy_points.csv"),
+    read_csv("../../Data/scraped_odds/pointsbet_player_goals.csv"),
+    read_csv("../../Data/scraped_odds/pointsbet_player_tackles.csv"),
+    read_csv("../../Data/scraped_odds/pointsbet_player_marks.csv")
+  )
+
+pointsbet_sgm <-
+  pointsbet_sgm_list |> 
+  keep(~nrow(.x) > 0) |>
+  bind_rows() |>
+  rename(price = over_price) |>  
+  distinct(match, player_name, line, market_name, agency, .keep_all = TRUE) |>
+  select(-contains("under"))
+
+#===============================================================================
+# Function to get SGM data
+#=-=============================================================================
+
+# Create function to call the API
+get_sgm_pointsbet <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>% 
+      filter(player_name == player_names[[i]] &
+             line == stat_counts[i] &
+               market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  id_list <- as.character(filtered_df$OutcomeKey)
+  market_id_list <- as.character(filtered_df$MarketKey)
+  event_key <- as.character(filtered_df$EventKey[1])
+  
+  selected_outcomes <- lapply(1:length(id_list), function(i) 
+    list(MarketKey = unbox(market_id_list[i]), OutcomeKey = unbox(id_list[i]))
+  )
+  
+  payload <- list(
+    EventKey = unbox(event_key),
+    SelectedOutcomes = selected_outcomes
+  )
+  
+  return(payload)
+}
+
+#==============================================================================
+# Make Post Request
+#==============================================================================
+
+call_sgm_pointsbet <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>% 
+      filter(player_name == player_names[i],
+             line == stat_counts[i],
+             market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  if (nrow(filtered_df) != length(player_names)) {
+    return(NULL)
+  }
+  
+  unadjusted_price <- prod(filtered_df$price)
+  
+  payload <- get_sgm_pointsbet(data, player_names, stat_counts, markets)
+  
+  url <- 'https://api.au.pointsbet.com/api/v2/sgm/price'
+  
+  headers <- c('User-Agent' = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Mobile Safari/537.36',
+               'Content-Type' = 'application/json;charset=UTF-8',
+               'Origin' = 'https://pointsbet.com.au',
+               'Referer' = 'https://pointsbet.com.au/')
+  
+  # Error handling for the POST request
+  tryCatch({
+    response <- POST(url, body = toJSON(payload), add_headers(.headers = headers), encode = "json")
+  }, error = function(e) {
+    message("Error in POST request: ", e)
+    return(NULL)
+  })
+  
+  # If there is no response, return NULL
+  if (is.null(response)) {
+    return(NULL)
+  }
+  
+  response_content <- content(response, "parsed")
+  adjusted_price <- as.numeric(response_content$price)
+  adjustment_factor <- adjusted_price / unadjusted_price
+  combined_list <- paste(player_names, stat_counts, sep = ": ")
+  player_string <- paste(combined_list, collapse = ", ")
+  market_string <- paste(markets, collapse = ", ")
+  
+  output_data <- data.frame(
+    Selections = player_string,
+    Markets = market_string,
+    Unadjusted_Price = unadjusted_price,
+    Adjusted_Price = adjusted_price,
+    Adjustment_Factor = adjustment_factor,
+    Agency = 'Pointsbet'
+  )
+  
+  return(output_data)
+}
+
+# call_sgm_pointsbet(
+#   data = pointsbet_sgm,
+# player_names = c("Charlie Curnow", "Blake Acres"),
+# stat_counts = c(2.5, 19.5),
+# markets = c("Player Goals", "Player Disposals")
+# )

--- a/Apps/AFL_APP/sportsbet_sgm.R
+++ b/Apps/AFL_APP/sportsbet_sgm.R
@@ -1,0 +1,132 @@
+library(httr)
+library(jsonlite)
+library(dplyr)
+library(purrr)
+library(mongolite)
+library(tidyverse)
+
+# Sportsbet SGM-----------------------------------------------------------------
+sportsbet_sgm <-
+  read_csv("../../Data/scraped_odds/sportsbet_player_disposals.csv") |> 
+  bind_rows(read_csv("../../Data/scraped_odds/sportsbet_player_goals.csv")) |> 
+  bind_rows(read_csv("../../Data/scraped_odds/sportsbet_player_tackles.csv")) |>
+  bind_rows(read_csv("../../Data/scraped_odds/sportsbet_player_marks.csv")) |>
+  bind_rows(read_csv("../../Data/scraped_odds/sportsbet_player_kicks.csv")) |>
+  bind_rows(read_csv("../../Data/scraped_odds/sportsbet_player_handballs.csv")) |>
+  rename(price = over_price) |> 
+  distinct(match, player_name, line, market_name, agency, .keep_all = TRUE) |> 
+  select(-contains("under"))
+
+sportsbet_sgm <-
+  rename(
+    sportsbet_sgm,
+    eventExternalId = event_external_id ,
+    competitionExternalId = competition_external_id,
+    classExternalId = class_external_id ,
+    marketExternalId = market_id,
+    outcomeExternalId = player_id
+  )
+
+#==============================================================================
+# Function to get SGM data
+#=-=============================================================================
+
+get_sgm_sportsbet <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>%
+      filter(player_name == player_names[i],
+             line == stat_counts[i],
+             market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  outcomes_list <- lapply(1:nrow(filtered_df), function(i) {
+    list(marketExternalId = as.numeric(filtered_df$marketExternalId[i]),
+         outcomeExternalId = as.numeric(filtered_df$outcomeExternalId[i]))
+  })
+  
+  payload <- list(
+    classExternalId = as.numeric(filtered_df$classExternalId[1]),
+    competitionExternalId = as.numeric(filtered_df$competitionExternalId[1]),
+    eventExternalId = as.numeric(filtered_df$eventExternalId[1]),
+    outcomesExternalIds = outcomes_list
+  )
+  
+  return(payload)
+}
+
+#==============================================================================
+# Make Post Request
+#==============================================================================
+
+call_sgm_sportsbet <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>%
+      filter(player_name == player_names[i],
+             line == stat_counts[i],
+             market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  if (nrow(filtered_df) != length(player_names)) {
+    return(NULL)
+  }
+  
+  unadjusted_price <- prod(filtered_df$price)
+  
+  payload <- get_sgm_sportsbet(data, player_names, stat_counts, markets)
+  
+  url <- 'https://www.sportsbet.com.au/apigw/multi-pricer/combinations/price'
+  
+  headers <- c('User-Agent' = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Mobile Safari/537.36',
+               'Content-Type' = 'application/json;charset=UTF-8')
+  
+  response <- POST(url, body = toJSON(payload, auto_unbox = TRUE), add_headers(.headers = headers), encode = "json")
+  
+  # Check if the request was successful
+  if (http_error(response)) {
+    stop("API request failed: ", content(response, "text"))
+  }
+  
+  response_content <- content(response, "parsed")
+  
+  # Check if the response contains the expected data
+  if (!"price" %in% names(response_content)) {
+    stop("Unexpected API response: 'price' not found")
+  }
+  
+  adjusted_price <- 1 + (response_content$price$numerator / response_content$price$denominator)
+  adjustment_factor <- adjusted_price / unadjusted_price
+  
+  combined_list <- paste(player_names, stat_counts, sep = ": ")
+  player_string <- paste(combined_list, collapse = ", ")
+  market_string <- paste(markets, collapse = ", ")
+  
+  output_data <- data.frame(
+    Selections = player_string,
+    Markets = market_string,
+    Unadjusted_Price = unadjusted_price,
+    Adjusted_Price = adjusted_price,
+    Adjustment_Factor = adjustment_factor,
+    Agency = 'Sportsbet'
+  )
+  
+  return(output_data)
+}
+
+# call_sgm_sportsbet(
+#   data = sportsbet_sgm,
+#   player_names = c("Lachie Neale", "Dayne Zorko"),
+#   stat_counts = c(24.5, 24.5),
+#   markets = c("Player Disposals", "Player Disposals")
+# )

--- a/Apps/AFL_APP/tab_sgm.R
+++ b/Apps/AFL_APP/tab_sgm.R
@@ -1,0 +1,176 @@
+library(httr)
+library(jsonlite)
+library(tidyverse)
+library(purrr)
+library(R.utils)
+
+# TAB SGM-----------------------------------------------------------------------
+tab_sgm_list <-
+  list(
+  read_csv("../../Data/scraped_odds/tab_player_disposals.csv"),
+  read_csv("../../Data/scraped_odds/tab_player_goals.csv"),
+  read_csv("../../Data/scraped_odds/tab_player_tackles.csv"),
+  read_csv("../../Data/scraped_odds/tab_player_marks.csv")
+)
+
+tab_sgm <-
+  tab_sgm_list |> 
+  keep(~nrow(.x) > 0) |>
+  bind_rows() |>
+  rename(price = over_price) |>  
+  distinct(match, player_name, line, market_name, agency, .keep_all = TRUE) |>
+  select(-contains("under"))
+
+#==============================================================================
+# Function to get SGM data
+#===============================================================================
+
+# Function to get SGM data
+get_sgm_tab <- function(data, player_names, stat_counts, markets) {
+  if (length(player_names) != length(stat_counts)) {
+    stop("Both lists should have the same length")
+  }
+  
+  filtered_df <- data.frame()
+  for (i in seq_along(player_names)) {
+    temp_df <- data %>% 
+      filter(player_name == player_names[i] &
+               line == stat_counts[i] &
+               market_name == markets[i])
+    filtered_df <- bind_rows(filtered_df, temp_df)
+  }
+  
+  # Get the 'id' column as a list
+  id_list <- filtered_df$prop_id
+  
+  # Create the propositions list using the id_list
+  propositions <- lapply(id_list, function(id) list(type = unbox("WIN"), propositionId = unbox(id)))
+  
+  return(propositions)
+}
+
+#==============================================================================
+# Make Post Request
+#==============================================================================
+
+# Make Post Request
+call_sgm_tab <- function(data, player_names, stat_counts, markets) {
+  tryCatch({
+    if (length(player_names) != length(stat_counts)) {
+      stop("Both lists should have the same length")
+    }
+    
+    filtered_df <- data.frame()
+    for (i in seq_along(player_names)) {
+      temp_df <- data %>% 
+        filter(player_name == player_names[i] &
+                 line == stat_counts[i] &
+                 market_name == markets[i])
+      filtered_df <- bind_rows(filtered_df, temp_df)
+    }
+    
+    if (nrow(filtered_df) != length(player_names)) {
+      return(NULL)
+    }
+    
+    # Unadjusted price
+    unadjusted_price <- prod(filtered_df$price)
+    
+    # Get propositions
+    propositions <- get_sgm_tab(data, player_names, stat_counts, markets)
+    
+    url <- "https://api.beta.tab.com.au/v1/pricing-service/enquiry"
+    
+    headers <- c(
+      "Accept" = "application/json, text/plain, */*",
+      "Accept-Encoding" = "gzip, deflate, br, zstd",
+      "Accept-Language" = "en-US,en;q=0.9",
+      "Content-Type" = "application/json;charset=UTF-8",
+      "Origin" = "https://www.tab.com.au",
+      "Referer" = "https://www.tab.com.au/",
+      "User-Agent" = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+      "sec-ch-ua" = '"Chromium";v="136", "Google Chrome";v="136", "Not.A/Brand";v="99"',
+      "sec-ch-ua-mobile" = "?0",
+      "sec-ch-ua-platform" = '"macOS"',
+      "Cookie" = "YOUR_COOKIE_STRING_HERE"  # You'll need to add the full cookie string
+    )
+    
+    payload <- list(
+      clientDetails = list(jurisdiction = unbox("SA"), channel = unbox("web")),
+      bets = list(
+        list(
+          type = unbox("FIXED_ODDS"),
+          legs = list(
+            list(
+              type = unbox("SAME_GAME_MULTI"),
+              propositions = propositions
+            )
+          )
+        )
+      ),
+      returnValidationMatrix = unbox(TRUE)  # Added this line
+    )
+    
+    # Try response, if nothing in 3 seconds, make it null
+    response <- tryCatch({
+      POST(url, 
+           body = toJSON(payload), 
+           add_headers(.headers = headers), 
+           encode = "json", 
+           timeout(5),
+           config = config(http_version = 1.1))  # Force HTTP/1.1
+    }, error = function(e) {
+      return(NULL)
+    })
+    
+    if(is.null(response)) {
+      return(data.frame(
+        Selections = NA_character_,
+        Markets = NA_character_,
+        Unadjusted_Price = NA_real_,
+        Adjusted_Price = NA_real_,
+        Adjustment_Factor = NA_real_,
+        Agency = NA_character_
+      ))
+    }
+    
+    response_content <- content(response, "parsed")
+    adjusted_price <- as.numeric(response_content$bets[[1]]$legs[[1]]$odds$decimal)
+    adjustment_factor <- adjusted_price / unadjusted_price
+    combined_list <- paste(player_names, stat_counts, sep = ": ")
+    market_string <- paste(markets, collapse = ", ")
+    player_string <- paste(combined_list, collapse = ", ")
+    
+    output_data <- tryCatch({
+      data.frame(
+        Selections = player_string,
+        Markets = market_string,
+        Unadjusted_Price = unadjusted_price,
+        Adjusted_Price = adjusted_price,
+        Adjustment_Factor = adjustment_factor,
+        Agency = 'TAB'
+      )
+    }, error = function(e) {
+      data.frame(
+        Selections = NA_character_,
+        Markets = NA_character_,
+        Unadjusted_Price = NA_real_,
+        Adjusted_Price = NA_real_,
+        Adjustment_Factor = NA_real_,
+        Agency = NA_character_
+      )
+    })
+    
+    return(output_data)
+    
+  }, error = function(e) {
+    print(paste("Error: ", e))
+  })
+}
+
+# call_sgm_tab(
+#   data = tab_sgm,
+#   player_names = c("Zach Guthrie", "Gryan Miers"),
+#   stat_counts = c(14.5, 19.5),
+#   markets = c("Player Disposals", "Player Disposals")
+# )


### PR DESCRIPTION
This commit integrates the SGM (Same Game Multi) betting tools into the main AFL analytics shiny app. The merged app now provides comprehensive analytics and betting optimization tools in a single unified interface.

Changes:
- Added 3 new tabs to main AFL app: SGM, Cross Game Multi, Player Combos
- Copied all SGM module files (bet365, betright, tab, sportsbet, pointsbet, neds, dabble, palmerbet, player_combos) to AFL_APP directory
- Integrated SGM data loading and functions into main app setup
- Added compare_sgm() and compare_cgm() functions for multi-agency comparison
- Added disposals_display dataframe with market-best odds tracking
- Added correlation matrix for player performance analysis in SGMs
- All original AFL app tabs remain unchanged (Player Stats, Team Stats, Odds Screen, With/Without Teammate, Player Correlations)

The app now has 9 tabs total:
- 6 original AFL analytics tabs
- 3 new SGM betting optimization tabs